### PR TITLE
Add docs and refine demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # PHMGA
+
+This repository contains a prototype implementation of a Predictive Health Management (PHM)
+system using LangGraph. The code defines a small set of self-describing operators
+and demonstrates how they can be executed in a graph-based pipeline.
+
+See [docs/TUTORIAL.md](docs/TUTORIAL.md) for a quick walkthrough of the demo
+pipeline.

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -1,0 +1,17 @@
+# PHM Demo Tutorial
+
+This tutorial walks through the minimal pipeline implemented in `src/phm_demo.py`.
+
+1. **Generate Example Signals**
+   - Random reference signals are created for four labels.
+   - A single test signal is generated.
+   - A simple processing plan is prepared using the operator factory.
+2. **Build The Graph**
+   - The demo uses the `StateGraph` API to define a linear flow:
+     planner -> execute -> decide -> report.
+   - Each node updates the shared state and passes it along.
+3. **Run The Demo**
+   - Execute `python -m src.phm_demo` to process the signals and print the predicted label.
+
+The demo showcases how operators can be combined in a LangGraph graph. The `plan`
+list can be extended with additional operators to perform more complex analysis.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ langsmith
 langchain-community
 langchain-core
 langchain-openai
-langchain_google_genai 
+langchain_google_genai
 notebook
 tavily-python
 wikipedia
@@ -14,3 +14,5 @@ trustcall
 langgraph-cli[inmem]
 google-generativeai
 google.genai
+numpy
+scipy

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,6 @@
-from .graph import graph
+"""Main package entry for PHMGA."""
 
-__all__ = ["graph"]
+from typing import List
+
+__all__: List[str] = ["phm_demo", "tools"]
+

--- a/src/phm_demo.py
+++ b/src/phm_demo.py
@@ -1,0 +1,127 @@
+"""Minimal demonstration pipeline for PHM operators."""
+
+from __future__ import annotations
+
+from typing import TypedDict, List, Dict
+
+import numpy as np
+from langgraph.graph import StateGraph, END
+
+from src.tools.schemas import PHMOperator, SimilarityOperator
+from src.tools.factory import create_operator
+
+class DemoState(TypedDict):
+    """Shared state for the demo graph."""
+
+    plan: List[PHMOperator]
+    reference_signals: Dict[str, np.ndarray]
+    test_signal: np.ndarray
+    result: str
+    output: str | None
+
+
+def generate_signals() -> DemoState:
+    """Create a starting state with random signals and a simple plan."""
+
+    rng = np.random.default_rng(0)
+
+    ref_signals = {
+        f"class_{i}": rng.normal(size=(1, 128, 1)) for i in range(4)
+    }
+    test_signal = rng.normal(size=(1, 128, 1))
+
+    # The plan contains two operators executed sequentially.
+    plan_dicts = [
+        {"op_name": "patch", "patch_size": 32, "stride": 16},
+        {"op_name": "mean"},
+    ]
+    plan = [create_operator(d) for d in plan_dicts]
+
+    return {
+        "plan": plan,
+        "reference_signals": ref_signals,
+        "test_signal": test_signal,
+        "result": "",
+        "output": None,
+    }
+
+
+def planner(state: DemoState) -> DemoState:
+    """Return the state unchanged (placeholder for LLM planner)."""
+
+    return state
+
+
+def tool_executor(state: DemoState) -> DemoState:
+    """Execute the plan on test and reference signals."""
+
+    data = state["test_signal"]
+    for op in state["plan"]:
+        data = op.execute(data)
+    state["test_signal"] = data
+
+    ref_processed: Dict[str, np.ndarray] = {}
+    for label, sig in state["reference_signals"].items():
+        ref = sig
+        for op in state["plan"]:
+            ref = op.execute(ref)
+        ref_processed[label] = ref
+
+    state["reference_signals"] = ref_processed
+    return state
+
+
+def decide(state: DemoState) -> DemoState:
+    """Select the reference signal most similar to the test signal."""
+
+    test_feat = state["test_signal"]
+    best_label = ""
+    best_score = 0.0
+
+    for label, feat in state["reference_signals"].items():
+        sim_op = SimilarityOperator()
+        if sim_op.execute(test_feat, ref=feat):
+            dot = np.vdot(test_feat, feat)
+            norm = np.linalg.norm(test_feat) * np.linalg.norm(feat)
+            score = float(abs(dot) / norm)
+            if score > best_score:
+                best_score = score
+                best_label = label
+
+    state["result"] = best_label or "unknown"
+    return state
+
+
+def reporter(state: DemoState) -> DemoState:
+    """Format the final result for display."""
+
+    state["output"] = f"Predicted label: {state['result']}"
+    return state
+
+
+# Build graph
+builder = StateGraph(DemoState)
+builder.add_node("planner", planner)
+builder.add_node("execute", tool_executor)
+builder.add_node("decide", decide)
+builder.add_node("report", reporter)
+
+builder.set_entry_point("planner")
+builder.add_edge("planner", "execute")
+builder.add_edge("execute", "decide")
+builder.add_edge("decide", "report")
+builder.add_edge("report", END)
+
+demo_graph = builder.compile()
+
+
+def main() -> None:
+    """Run the demo graph and print the classification result."""
+
+    state = generate_signals()
+    result = demo_graph.invoke(state)
+    print(result["output"])
+
+
+if __name__ == "__main__":
+    main()

--- a/src/state.py
+++ b/src/state.py
@@ -5,6 +5,7 @@ from typing import TypedDict
 
 from langgraph.graph import add_messages
 from typing_extensions import Annotated
+from .tools.schemas import PHMOperator
 
 
 import operator
@@ -46,3 +47,25 @@ class WebSearchState(TypedDict):
 @dataclass(kw_only=True)
 class SearchStateOutput:
     running_summary: str = field(default=None)  # Final report
+
+class PHMState(TypedDict):
+    """Graph state for PHM system."""
+
+    user_instruction: str
+    reference_signal: list
+    test_signal: list
+
+    initial_plan: list[dict]
+    current_plan: list[PHMOperator]
+    needs_deep_research: bool
+    iteration_count: int
+
+    processed_signals: Annotated[list, operator.add]
+    extracted_features: Annotated[list, operator.add]
+    analysis_summary: str | None
+    bug_report: dict | None
+    reflection_history: list
+
+    final_markdown_report: str
+    latex_sections: dict
+    final_latex_report: str | None

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,0 +1,3 @@
+"""Tool subpackage exposing operator helpers."""
+
+__all__ = ["factory", "functions", "schemas"]

--- a/src/tools/factory.py
+++ b/src/tools/factory.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from .schemas import (
+    PHMOperator,
+    PatchOperator,
+    CopyOperator,
+    FFTOperator,
+    MeanOperator,
+    KurtosisOperator,
+    SimilarityOperator,
+)
+
+
+_OPERATOR_REGISTRY: Dict[str, Type[PHMOperator]] = {
+    "patch": PatchOperator,
+    "copy": CopyOperator,
+    "fft": FFTOperator,
+    "mean": MeanOperator,
+    "kurtosis": KurtosisOperator,
+    "similarity": SimilarityOperator,
+}
+
+
+def create_operator(data: Dict) -> PHMOperator:
+    op_name = data.get("op_name")
+    if op_name not in _OPERATOR_REGISTRY:
+        raise ValueError(f"Unknown operator {op_name}")
+    cls = _OPERATOR_REGISTRY[op_name]
+    return cls(**{k: v for k, v in data.items() if k != "op_name"})

--- a/src/tools/functions.py
+++ b/src/tools/functions.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from scipy.stats import kurtosis
+
+
+def patch_signal(data: np.ndarray, patch_size: int, stride: int) -> np.ndarray:
+    """Split signal into overlapping patches."""
+    b, l, c = data.shape
+    patches = []
+    for start in range(0, l - patch_size + 1, stride):
+        patch = data[:, start : start + patch_size, :]
+        patches.append(patch)
+    result = np.stack(patches, axis=1)
+    return result
+
+
+def copy_signal(data: np.ndarray, num_copies: int) -> np.ndarray:
+    """Repeat the input signal ``num_copies`` times along a new dimension."""
+
+    return np.repeat(data[:, None, :, :], num_copies, axis=1)
+
+
+def fft_signal(data: np.ndarray) -> np.ndarray:
+    """Compute the FFT along the time axis."""
+
+    return np.fft.rfft(data, axis=-2)
+
+
+def mean_signal(data: np.ndarray) -> np.ndarray:
+    """Return the mean along the time axis."""
+
+    return data.mean(axis=-2)
+
+
+def kurtosis_signal(data: np.ndarray) -> np.ndarray:
+    """Compute the kurtosis along the time axis."""
+
+    return kurtosis(data, axis=-2)
+
+
+def similarity(
+    feat: np.ndarray,
+    ref_feat: np.ndarray,
+    method: str,
+    threshold: float,
+) -> bool:
+    """Return ``True`` if ``feat`` is similar to ``ref_feat`` using ``method``."""
+
+    if method == "cosine":
+        dot = np.vdot(feat, ref_feat)
+        norm = np.linalg.norm(feat) * np.linalg.norm(ref_feat)
+        score = float(abs(dot) / norm)
+        return score >= threshold
+    score = float(np.linalg.norm(feat - ref_feat))
+    return score <= threshold

--- a/src/tools/schemas.py
+++ b/src/tools/schemas.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import ClassVar, Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class PHMOperator(BaseModel):
+    """Base class for all PHM system operators."""
+
+    op_name: str = Field(..., description="Unique operator name")
+    op_type: Literal[
+        "Dimension-Increasing",
+        "Dimension-Identity",
+        "Dimension-Reducing",
+        "Decision",
+    ]
+    description: ClassVar[str] = ""
+
+    def execute(self, data: Any, **kwargs) -> Any:  # pragma: no cover - abstract
+        """Execute the operator on the provided data."""
+        raise NotImplementedError
+
+
+class PatchOperator(PHMOperator):
+    op_name: str = "patch"
+    op_type: Literal["Dimension-Increasing"] = "Dimension-Increasing"
+    description: ClassVar[str] = (
+        "Split a (B,L,C) signal into patches of shape (B,P,L',C)."
+    )
+    patch_size: int = 256
+    stride: int = 128
+
+    def execute(self, data: Any, **kwargs) -> Any:
+        from .functions import patch_signal
+
+        return patch_signal(data, self.patch_size, self.stride)
+
+
+class CopyOperator(PHMOperator):
+    op_name: str = "copy"
+    op_type: Literal["Dimension-Increasing"] = "Dimension-Increasing"
+    description: ClassVar[str] = (
+        "Duplicate the input signal P times. Input (B,L,C) -> (B,P,L,C)."
+    )
+    num_copies: int = 2
+
+    def execute(self, data: Any, **kwargs) -> Any:
+        from .functions import copy_signal
+
+        return copy_signal(data, self.num_copies)
+
+
+class FFTOperator(PHMOperator):
+    op_name: str = "fft"
+    op_type: Literal["Dimension-Identity"] = "Dimension-Identity"
+    description: ClassVar[str] = (
+        "Apply FFT along the last dimension. (...,L,C) -> (...,F,C)."
+    )
+
+    def execute(self, data: Any, **kwargs) -> Any:
+        from .functions import fft_signal
+
+        return fft_signal(data)
+
+
+class MeanOperator(PHMOperator):
+    op_name: str = "mean"
+    op_type: Literal["Dimension-Reducing"] = "Dimension-Reducing"
+    description: ClassVar[str] = (
+        "Compute mean along time axis. (B,L,C) -> (B,C)."
+    )
+
+    def execute(self, data: Any, **kwargs) -> Any:
+        from .functions import mean_signal
+
+        return mean_signal(data)
+
+
+class KurtosisOperator(PHMOperator):
+    op_name: str = "kurtosis"
+    op_type: Literal["Dimension-Reducing"] = "Dimension-Reducing"
+    description: ClassVar[str] = (
+        "Compute kurtosis along time axis. (B,L,C) -> (B,C)."
+    )
+
+    def execute(self, data: Any, **kwargs) -> Any:
+        from .functions import kurtosis_signal
+
+        return kurtosis_signal(data)
+
+
+class SimilarityOperator(PHMOperator):
+    op_name: str = "similarity"
+    op_type: Literal["Decision"] = "Decision"
+    description: ClassVar[str] = (
+        "Compare test features with reference features and return similarity score."
+    )
+    method: str = "cosine"
+    threshold: float = 0.8
+
+    def execute(self, data: Any, ref: Any | None = None, **kwargs) -> Any:
+        from .functions import similarity
+
+        if ref is None:
+            raise ValueError("Reference data required for similarity computation")
+        return similarity(data, ref, self.method, self.threshold)

--- a/tests/test_phm_tools.py
+++ b/tests/test_phm_tools.py
@@ -1,0 +1,38 @@
+import numpy as np
+from src.tools.functions import (
+    patch_signal,
+    copy_signal,
+    fft_signal,
+    mean_signal,
+    kurtosis_signal,
+    similarity,
+)
+
+
+def test_patch_signal():
+    x = np.arange(8).reshape(1, 8, 1)
+    result = patch_signal(x, 4, 2)
+    assert result.shape == (1, 3, 4, 1)
+
+
+def test_copy_signal():
+    x = np.ones((1, 4, 1))
+    result = copy_signal(x, 3)
+    assert result.shape == (1, 3, 4, 1)
+    assert np.all(result[0, 0] == 1)
+
+
+def test_mean_kurtosis():
+    x = np.array([[[1.0], [2.0], [3.0], [4.0]]])
+    mean = mean_signal(x)
+    kurt = kurtosis_signal(x)
+    assert np.isclose(mean[0, 0], 2.5)
+    assert kurt.shape == (1, 1)
+
+
+def test_fft_similarity():
+    x = np.linspace(0, 1, 8).reshape(1, 8, 1)
+    fft = fft_signal(x)
+    assert fft.shape[0] == 1
+    ref = fft.copy()
+    assert similarity(fft, ref, "cosine", 0.9)


### PR DESCRIPTION
## Summary
- document demo usage in a new tutorial file
- clean up README
- improve `phm_demo.py` structure with comments and `main`
- expose packages via `__all__`

## Testing
- `pytest -q`
- `python -m src.phm_demo`


------
https://chatgpt.com/codex/tasks/task_e_6886b1e7a36483238bd3b66c15b54f48