### PR TITLE
Add tutorial and refine demo pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # PHMGA
+
+This repository demonstrates a minimal Prognostics and Health Management (PHM) workflow implemented with [LangGraph](https://github.com/langchain-ai/langgraph).
+
+The code defines a small set of self–describing operators based on Pydantic. Each operator exposes its parameters and an `execute` method so a planner can build processing plans dynamically.
+
+## Demo Pipeline
+
+```
+Planner -> Tool Executor -> Decision -> Report
+```
+
+The demo shows how to generate random reference signals, run a simple plan (patch and mean) on both the test and reference data, and classify the test signal using cosine similarity.
+
+### Running
+
+```bash
+pip install -r requirements.txt
+python -m src.phm_demo
+```
+
+This will print a predicted label for the test signal.
+
+### Extending
+
+- Implement additional operators in `src/tools/functions.py` and `src/tools/schemas.py`.
+- Build more complex graphs using `langgraph` and the provided operators.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ langsmith
 langchain-community
 langchain-core
 langchain-openai
-langchain_google_genai 
+langchain_google_genai
 notebook
 tavily-python
 wikipedia
@@ -14,3 +14,5 @@ trustcall
 langgraph-cli[inmem]
 google-generativeai
 google.genai
+numpy
+scipy

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,6 @@
-from .graph import graph
+"""PHMGA package."""
 
-__all__ = ["graph"]
+from typing import List
+
+__all__: List[str] = []
+

--- a/src/phm_demo.py
+++ b/src/phm_demo.py
@@ -1,0 +1,121 @@
+"""Demonstration pipeline for PHM operators and LangGraph."""
+
+from __future__ import annotations
+
+from typing import Dict, List, TypedDict
+
+import numpy as np
+from langgraph.graph import END, StateGraph
+
+from src.tools.factory import create_operator
+from src.tools.schemas import PHMOperator, SimilarityOperator
+
+class DemoState(TypedDict):
+    """State used by the demonstration graph."""
+
+    plan: List[PHMOperator]
+    reference_signals: Dict[str, np.ndarray]
+    test_signal: np.ndarray
+    result: str
+    output: str | None
+
+
+def generate_signals() -> DemoState:
+    """Generate random signals and a simple processing plan."""
+
+    rng = np.random.default_rng(0)
+    ref_signals = {f"class_{i}": rng.normal(size=(1, 128, 1)) for i in range(4)}
+    test_signal = rng.normal(size=(1, 128, 1))
+
+    plan_dicts = [
+        {"op_name": "patch", "patch_size": 32, "stride": 16},
+        {"op_name": "mean"},
+    ]
+    plan = [create_operator(d) for d in plan_dicts]
+
+    return {
+        "plan": plan,
+        "reference_signals": ref_signals,
+        "test_signal": test_signal,
+        "result": "",
+        "output": None,
+    }
+
+
+def planner(state: DemoState) -> DemoState:
+    """Placeholder planner simply returns the provided state."""
+
+    return state
+
+
+def tool_executor(state: DemoState) -> DemoState:
+    """Run each operator on the test and reference signals."""
+
+    data = state["test_signal"]
+    for op in state["plan"]:
+        data = op.execute(data)
+    state["test_signal"] = data
+
+    ref_processed: Dict[str, np.ndarray] = {}
+    for label, sig in state["reference_signals"].items():
+        ref = sig
+        for op in state["plan"]:
+            ref = op.execute(ref)
+        ref_processed[label] = ref
+    state["reference_signals"] = ref_processed
+
+    return state
+
+
+def decide(state: DemoState) -> DemoState:
+    """Assign the label with highest similarity to the test signal."""
+
+    test_feat = state["test_signal"]
+    best_label = ""
+    best_score = 0.0
+    for label, feat in state["reference_signals"].items():
+        sim_op = SimilarityOperator()
+        if sim_op.execute(test_feat, ref=feat):
+            dot = np.vdot(test_feat, feat)
+            norm = np.linalg.norm(test_feat) * np.linalg.norm(feat)
+            score = float(abs(dot) / norm)
+            if score > best_score:
+                best_score = score
+                best_label = label
+    state["result"] = best_label or "unknown"
+    return state
+
+
+def reporter(state: DemoState) -> DemoState:
+    """Format the classification result."""
+
+    state["output"] = f"Predicted label: {state['result']}"
+    return state
+
+
+def build_demo_graph() -> StateGraph:
+    """Return a compiled demonstration graph."""
+
+    builder = StateGraph(DemoState)
+    builder.add_node("planner", planner)
+    builder.add_node("execute", tool_executor)
+    builder.add_node("decide", decide)
+    builder.add_node("report", reporter)
+
+    builder.set_entry_point("planner")
+    builder.add_edge("planner", "execute")
+    builder.add_edge("execute", "decide")
+    builder.add_edge("decide", "report")
+    builder.add_edge("report", END)
+
+    return builder.compile()
+
+
+__all__ = ["DemoState", "build_demo_graph", "generate_signals"]
+
+
+if __name__ == "__main__":
+    graph = build_demo_graph()
+    state = generate_signals()
+    result = graph.invoke(state)
+    print(result["output"])

--- a/src/state.py
+++ b/src/state.py
@@ -5,6 +5,7 @@ from typing import TypedDict
 
 from langgraph.graph import add_messages
 from typing_extensions import Annotated
+from .tools.schemas import PHMOperator
 
 
 import operator
@@ -46,3 +47,25 @@ class WebSearchState(TypedDict):
 @dataclass(kw_only=True)
 class SearchStateOutput:
     running_summary: str = field(default=None)  # Final report
+
+class PHMState(TypedDict):
+    """Graph state for PHM system."""
+
+    user_instruction: str
+    reference_signal: list
+    test_signal: list
+
+    initial_plan: list[dict]
+    current_plan: list[PHMOperator]
+    needs_deep_research: bool
+    iteration_count: int
+
+    processed_signals: Annotated[list, operator.add]
+    extracted_features: Annotated[list, operator.add]
+    analysis_summary: str | None
+    bug_report: dict | None
+    reflection_history: list
+
+    final_markdown_report: str
+    latex_sections: dict
+    final_latex_report: str | None

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,0 +1,23 @@
+"""Utilities and operator definitions for PHMGA."""
+
+from .factory import create_operator
+from .schemas import (
+    PHMOperator,
+    PatchOperator,
+    CopyOperator,
+    FFTOperator,
+    MeanOperator,
+    KurtosisOperator,
+    SimilarityOperator,
+)
+
+__all__ = [
+    "create_operator",
+    "PHMOperator",
+    "PatchOperator",
+    "CopyOperator",
+    "FFTOperator",
+    "MeanOperator",
+    "KurtosisOperator",
+    "SimilarityOperator",
+]

--- a/src/tools/factory.py
+++ b/src/tools/factory.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from .schemas import (
+    PHMOperator,
+    PatchOperator,
+    CopyOperator,
+    FFTOperator,
+    MeanOperator,
+    KurtosisOperator,
+    SimilarityOperator,
+)
+
+
+_OPERATOR_REGISTRY: Dict[str, Type[PHMOperator]] = {
+    "patch": PatchOperator,
+    "copy": CopyOperator,
+    "fft": FFTOperator,
+    "mean": MeanOperator,
+    "kurtosis": KurtosisOperator,
+    "similarity": SimilarityOperator,
+}
+
+
+def create_operator(data: Dict) -> PHMOperator:
+    op_name = data.get("op_name")
+    if op_name not in _OPERATOR_REGISTRY:
+        raise ValueError(f"Unknown operator {op_name}")
+    cls = _OPERATOR_REGISTRY[op_name]
+    return cls(**{k: v for k, v in data.items() if k != "op_name"})

--- a/src/tools/functions.py
+++ b/src/tools/functions.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from scipy.stats import kurtosis
+
+
+def patch_signal(data: np.ndarray, patch_size: int, stride: int) -> np.ndarray:
+    """Split signal into overlapping patches."""
+    b, l, c = data.shape
+    patches = []
+    for start in range(0, l - patch_size + 1, stride):
+        patch = data[:, start : start + patch_size, :]
+        patches.append(patch)
+    result = np.stack(patches, axis=1)
+    return result
+
+
+def copy_signal(data: np.ndarray, num_copies: int) -> np.ndarray:
+    """Repeat the input signal ``num_copies`` times along a new dimension."""
+
+    return np.repeat(data[:, None, :, :], num_copies, axis=1)
+
+
+def fft_signal(data: np.ndarray) -> np.ndarray:
+    """Compute the FFT along the time axis."""
+
+    return np.fft.rfft(data, axis=-2)
+
+
+def mean_signal(data: np.ndarray) -> np.ndarray:
+    """Return the mean along the time axis."""
+
+    return data.mean(axis=-2)
+
+
+def kurtosis_signal(data: np.ndarray) -> np.ndarray:
+    """Compute the kurtosis along the time axis."""
+
+    return kurtosis(data, axis=-2)
+
+
+def similarity(
+    feat: np.ndarray,
+    ref_feat: np.ndarray,
+    method: str,
+    threshold: float,
+) -> bool:
+    """Return ``True`` if ``feat`` is similar to ``ref_feat`` using ``method``."""
+
+    if method == "cosine":
+        dot = np.vdot(feat, ref_feat)
+        norm = np.linalg.norm(feat) * np.linalg.norm(ref_feat)
+        score = float(abs(dot) / norm)
+        return score >= threshold
+    score = float(np.linalg.norm(feat - ref_feat))
+    return score <= threshold

--- a/src/tools/schemas.py
+++ b/src/tools/schemas.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import ClassVar, Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class PHMOperator(BaseModel):
+    """Base class for all PHM system operators."""
+
+    op_name: str = Field(..., description="Unique operator name")
+    op_type: Literal[
+        "Dimension-Increasing",
+        "Dimension-Identity",
+        "Dimension-Reducing",
+        "Decision",
+    ]
+    description: ClassVar[str] = ""
+
+    def execute(self, data: Any, **kwargs) -> Any:  # pragma: no cover - abstract
+        """Execute the operator on the provided data."""
+        raise NotImplementedError
+
+
+class PatchOperator(PHMOperator):
+    op_name: str = "patch"
+    op_type: Literal["Dimension-Increasing"] = "Dimension-Increasing"
+    description: ClassVar[str] = (
+        "Split a (B,L,C) signal into patches of shape (B,P,L',C)."
+    )
+    patch_size: int = 256
+    stride: int = 128
+
+    def execute(self, data: Any, **kwargs) -> Any:
+        from .functions import patch_signal
+
+        return patch_signal(data, self.patch_size, self.stride)
+
+
+class CopyOperator(PHMOperator):
+    op_name: str = "copy"
+    op_type: Literal["Dimension-Increasing"] = "Dimension-Increasing"
+    description: ClassVar[str] = (
+        "Duplicate the input signal P times. Input (B,L,C) -> (B,P,L,C)."
+    )
+    num_copies: int = 2
+
+    def execute(self, data: Any, **kwargs) -> Any:
+        from .functions import copy_signal
+
+        return copy_signal(data, self.num_copies)
+
+
+class FFTOperator(PHMOperator):
+    op_name: str = "fft"
+    op_type: Literal["Dimension-Identity"] = "Dimension-Identity"
+    description: ClassVar[str] = (
+        "Apply FFT along the last dimension. (...,L,C) -> (...,F,C)."
+    )
+
+    def execute(self, data: Any, **kwargs) -> Any:
+        from .functions import fft_signal
+
+        return fft_signal(data)
+
+
+class MeanOperator(PHMOperator):
+    op_name: str = "mean"
+    op_type: Literal["Dimension-Reducing"] = "Dimension-Reducing"
+    description: ClassVar[str] = (
+        "Compute mean along time axis. (B,L,C) -> (B,C)."
+    )
+
+    def execute(self, data: Any, **kwargs) -> Any:
+        from .functions import mean_signal
+
+        return mean_signal(data)
+
+
+class KurtosisOperator(PHMOperator):
+    op_name: str = "kurtosis"
+    op_type: Literal["Dimension-Reducing"] = "Dimension-Reducing"
+    description: ClassVar[str] = (
+        "Compute kurtosis along time axis. (B,L,C) -> (B,C)."
+    )
+
+    def execute(self, data: Any, **kwargs) -> Any:
+        from .functions import kurtosis_signal
+
+        return kurtosis_signal(data)
+
+
+class SimilarityOperator(PHMOperator):
+    op_name: str = "similarity"
+    op_type: Literal["Decision"] = "Decision"
+    description: ClassVar[str] = (
+        "Compare test features with reference features and return similarity score."
+    )
+    method: str = "cosine"
+    threshold: float = 0.8
+
+    def execute(self, data: Any, ref: Any | None = None, **kwargs) -> Any:
+        from .functions import similarity
+
+        if ref is None:
+            raise ValueError("Reference data required for similarity computation")
+        return similarity(data, ref, self.method, self.threshold)

--- a/tests/test_demo_graph.py
+++ b/tests/test_demo_graph.py
@@ -1,0 +1,10 @@
+import numpy as np
+from src.phm_demo import build_demo_graph, generate_signals
+
+
+def test_demo_graph_runs():
+    graph = build_demo_graph()
+    state = generate_signals()
+    result = graph.invoke(state)
+    assert isinstance(result["output"], str)
+    assert result["result"]

--- a/tests/test_phm_tools.py
+++ b/tests/test_phm_tools.py
@@ -1,0 +1,38 @@
+import numpy as np
+from src.tools.functions import (
+    patch_signal,
+    copy_signal,
+    fft_signal,
+    mean_signal,
+    kurtosis_signal,
+    similarity,
+)
+
+
+def test_patch_signal():
+    x = np.arange(8).reshape(1, 8, 1)
+    result = patch_signal(x, 4, 2)
+    assert result.shape == (1, 3, 4, 1)
+
+
+def test_copy_signal():
+    x = np.ones((1, 4, 1))
+    result = copy_signal(x, 3)
+    assert result.shape == (1, 3, 4, 1)
+    assert np.all(result[0, 0] == 1)
+
+
+def test_mean_kurtosis():
+    x = np.array([[[1.0], [2.0], [3.0], [4.0]]])
+    mean = mean_signal(x)
+    kurt = kurtosis_signal(x)
+    assert np.isclose(mean[0, 0], 2.5)
+    assert kurt.shape == (1, 1)
+
+
+def test_fft_similarity():
+    x = np.linspace(0, 1, 8).reshape(1, 8, 1)
+    fft = fft_signal(x)
+    assert fft.shape[0] == 1
+    ref = fft.copy()
+    assert similarity(fft, ref, "cosine", 0.9)


### PR DESCRIPTION
## Summary
- document demo pipeline usage in README
- refactor `phm_demo` into clearer functions
- export utility functions in `src/tools`
- add simple graph test

## Testing
- `pytest -q`
- `python -m src.phm_demo`

------
https://chatgpt.com/codex/tasks/task_e_6886b1e7a36483238bd3b66c15b54f48