### PR TITLE
Add comprehensive tools self-tests and BandPowerOp fix

### DIFF
--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -40,3 +40,17 @@ __all__ = [
     "DecisionOp",
     "MultiVariableOp",
 ]
+
+
+if __name__ == "__main__":
+    print("--- Testing tools package ---")
+    # Ensure that operators from submodules are registered
+    assert "mean" in OP_REGISTRY, "MeanOp should be registered"
+    MeanOp = get_operator("mean")
+    import numpy as np
+
+    dummy = np.ones((1, 4, 1))
+    mean_result = MeanOp().execute(dummy)
+    assert mean_result.shape == (1, 1)
+
+    print("\n--- tools package tests passed! ---")


### PR DESCRIPTION
## Summary
- expand BandPowerOp to handle multiple frequency bands from time-domain input
- add standalone test harness for the tools package

## Testing
- `python -m src.tools.aggregate_schemas`
- `python -m src.tools.comparator_tool`
- `python -m src.tools.decision_schemas`
- `python -m src.tools.expand_schemas`
- `python -m src.tools.multi_schemas`
- `python -m src.tools.research_schemas`
- `python -m src.tools.signal_processing_schemas`
- `python -m src.tools.transform_schemas`
- `python -m src.tools.utils`
- `python -m src.tools.__init__`


------
https://chatgpt.com/codex/tasks/task_e_688e3c681f548323ab9ad51b7c36ec12